### PR TITLE
Fix the Item Dupe mentioned in #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2
+
+- [x] Fix the Item Dupe mentioned in [Issue 16](https://github.com/Erdragh/ProjectTableRefabricated/issues/16)
+
 # 1.0.0 - 1.0.1
 
 - [x] Project Table base functionality

--- a/FABRIC_CHANGELOG.txt
+++ b/FABRIC_CHANGELOG.txt
@@ -5,4 +5,4 @@ No formatting, just plain text. CurseForge support for it is terrible.
 
 Change logging starts below:
 ----------
-- Fixed Autopublishing
+- Fixed an Item Dupe related to storage accesses

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.14.22
 fabric_kotlin_version=1.10.8+kotlin.1.9.0
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=com.github.erdragh
 archives_base_name=projecttable
 release_type=release

--- a/src/main/kotlin/com/github/erdragh/projecttable/block/entity/ProjectTableBlockEntity.kt
+++ b/src/main/kotlin/com/github/erdragh/projecttable/block/entity/ProjectTableBlockEntity.kt
@@ -7,6 +7,7 @@ import com.github.erdragh.projecttable.utils.DelegatedContainer
 import com.github.erdragh.projecttable.utils.containerToNonNullList
 import com.github.erdragh.projecttable.utils.nonNullListIntoContainer
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Direction
 import net.minecraft.core.NonNullList
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.chat.Component
@@ -14,6 +15,7 @@ import net.minecraft.network.chat.TranslatableComponent
 import net.minecraft.world.Container
 import net.minecraft.world.ContainerHelper
 import net.minecraft.world.SimpleContainer
+import net.minecraft.world.WorldlyContainer
 import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.entity.player.Player
 import net.minecraft.world.inventory.AbstractContainerMenu
@@ -23,7 +25,7 @@ import net.minecraft.world.level.block.entity.BaseContainerBlockEntity
 import net.minecraft.world.level.block.state.BlockState
 
 class ProjectTableBlockEntity(pos: BlockPos, state: BlockState) :
-    BaseContainerBlockEntity(ModBlocks.PROJECT_TABLE_ENTITY_TYPE, pos, state), DelegatedContainer {
+    BaseContainerBlockEntity(ModBlocks.PROJECT_TABLE_ENTITY_TYPE, pos, state), DelegatedContainer, WorldlyContainer {
     private val container: SimpleContainer = SimpleContainer((1 + ProjectTableConfig.EXTRA_STORAGE_ROWS.get()) * 9)
 
     init {
@@ -44,6 +46,33 @@ class ProjectTableBlockEntity(pos: BlockPos, state: BlockState) :
 
     override fun stillValid(player: Player): Boolean {
         return player.position().distanceToSqr(blockPos.x + 0.5, blockPos.y + 0.5, blockPos.z + 0.5) < 5 * 5
+    }
+
+    override fun getSlotsForFace(side: Direction): IntArray {
+        if (ProjectTableConfig.STORAGE_INTERACTIONS.get()) {
+            // include the indices for the crafting slots only if they're actually enabled in the config
+            return if (ProjectTableConfig.INSERT_INTO_GRID.get()) IntArray(container.containerSize) { it } else IntArray(container.containerSize - 9) { it + 9 }
+        }
+        return IntArray(0)
+    }
+
+    override fun canPlaceItemThroughFace(index: Int, itemStack: ItemStack, direction: Direction?): Boolean {
+        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false;
+        val isCraftingSlot = index < 9
+        return if (isCraftingSlot) {
+            // you can only place items into the crafting grid from above and if it's enabled in the config
+            ProjectTableConfig.INSERT_INTO_GRID.get() && (direction?.equals(Direction.UP) == true)
+        } else {
+            // if placing items into the grid is enabled you can't insert into other slots from the top
+            if (ProjectTableConfig.INSERT_INTO_GRID.get()) direction?.equals(Direction.UP) != true else true
+        }
+    }
+
+    override fun canTakeItemThroughFace(index: Int, stack: ItemStack, direction: Direction): Boolean {
+        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false;
+        // you can't take items out of the crafting slots ever, easily leads to dupes,
+        // see Issue 16 (https://github.com/Erdragh/ProjectTableRefabricated/issues/16)
+        return index >= 9
     }
 
     override fun getDelegateContainer(): Container {

--- a/src/main/kotlin/com/github/erdragh/projecttable/block/entity/ProjectTableBlockEntity.kt
+++ b/src/main/kotlin/com/github/erdragh/projecttable/block/entity/ProjectTableBlockEntity.kt
@@ -57,7 +57,7 @@ class ProjectTableBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     override fun canPlaceItemThroughFace(index: Int, itemStack: ItemStack, direction: Direction?): Boolean {
-        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false;
+        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false
         val isCraftingSlot = index < 9
         return if (isCraftingSlot) {
             // you can only place items into the crafting grid from above and if it's enabled in the config
@@ -69,7 +69,7 @@ class ProjectTableBlockEntity(pos: BlockPos, state: BlockState) :
     }
 
     override fun canTakeItemThroughFace(index: Int, stack: ItemStack, direction: Direction): Boolean {
-        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false;
+        if (!ProjectTableConfig.STORAGE_INTERACTIONS.get()) return false
         // you can't take items out of the crafting slots ever, easily leads to dupes,
         // see Issue 16 (https://github.com/Erdragh/ProjectTableRefabricated/issues/16)
         return index >= 9

--- a/src/main/kotlin/com/github/erdragh/projecttable/config/ProjectTableConfig.kt
+++ b/src/main/kotlin/com/github/erdragh/projecttable/config/ProjectTableConfig.kt
@@ -6,6 +6,8 @@ object ProjectTableConfig {
     val SPEC: ForgeConfigSpec
 
     val EXTRA_STORAGE_ROWS: ForgeConfigSpec.IntValue
+    val STORAGE_INTERACTIONS: ForgeConfigSpec.BooleanValue
+    val INSERT_INTO_GRID: ForgeConfigSpec.BooleanValue
 
     init {
         val builder = ForgeConfigSpec.Builder()
@@ -14,6 +16,12 @@ object ProjectTableConfig {
 
         EXTRA_STORAGE_ROWS = builder.comment("How many rows of extra storage should a project table have?")
             .defineInRange("extraStorageRows", 2, 0, 5)
+
+        STORAGE_INTERACTIONS = builder.comment("Whether the inventory of the block can be interacted with from the outside")
+            .define("storageInteractions", true)
+
+        INSERT_INTO_GRID = builder.comment("Whether inputting items into the block starts in the crafting grid or the extra storage")
+            .define("insertIntoGrid", false)
 
         SPEC = builder.build()
     }


### PR DESCRIPTION
Accomplished by restricting storage accesses:
- Storage interactions other than the player can't take items out of the grid anymore
- Most storage interactions are restricted to the extra storage
- The storage interactions can be completely disabled via the config
- Added a config option so you can insert items into the crafting grid from the top side of the block. Off by default.